### PR TITLE
Bugfix/dce 1723 groups collapse button disappears when mouse over cf and crs

### DIFF
--- a/src/cueUtilities.js
+++ b/src/cueUtilities.js
@@ -300,9 +300,13 @@ module.exports = function (params, cy, api) {
           return false;
         }
 
+        function getAllGroups(cy) {
+          return cy.$('.cy-expand-collapse-collapsed-node').union(':parent');
+        }
+
         function getAllGroupsUnderEvent(cy, e) {
           const groupsUnderEvent = [];
-          const groups = cy.$('.cy-expand-collapse-collapsed-node').union(cy.$(':parent'));
+          const groups = getAllGroups(cy);
           for (let i = 0; i < groups.length; i++) {
             if (isInsideCompound(groups[i], e)) {
               groupsUnderEvent.push(groups[i]);
@@ -314,15 +318,16 @@ module.exports = function (params, cy, api) {
         function getAllGroupsWithHighestZDepth(groups) {
           let highestZDepthGroups = [];
           let highestZDepth = 0;
-          for (let i = 0; i < groups.length; i++) {
-            let currentZDepth = groups[i].zDepth();
+          groups.forEach((group) => {
+            let currentZDepth = group.zDepth();
+            // if we find groups with a higher zDepth, keep track of those
             if (currentZDepth > highestZDepth) {
               highestZDepth = currentZDepth;
-              highestZDepthGroups = [groups[i]];
+              highestZDepthGroups = [group];
             } else if (currentZDepth === highestZDepth) {
-              highestZDepthGroups.push(groups[i]);
+              highestZDepthGroups.push(group);
             }
-          }
+          });
           return highestZDepthGroups;
         }
 
@@ -342,6 +347,7 @@ module.exports = function (params, cy, api) {
             refreshCanvasImages();
           }
         }
+
         cy.on('mousemove', 'edge', data.eMouseMove = function(e) {
           drawCueOnHighestZDepthGroup(e);
         });
@@ -531,6 +537,7 @@ module.exports = function (params, cy, api) {
         cy.off('mouseover', 'node', data.eMouseOver)
           .off('mouseout', 'node', data.eMouseOut)
           .off('mousedown', 'node', data.eMouseDown)
+          .off('mousemove', 'node', data.eMouseMoveNode)
           .off('mouseup', 'node', data.eMouseUp)
           .off('free', 'node', data.eFree)
           .off('grab', 'node', data.eGrab)
@@ -563,6 +570,7 @@ module.exports = function (params, cy, api) {
         .on('mouseout', 'node', data.eMouseOut)
         .on('mousedown', 'node', data.eMouseDown)
         .on('mouseup', 'node', data.eMouseUp)
+        .on('mousemove', 'node', data.eMouseMoveNode)
         .on('free', 'node', data.eFree)
         .on('grab', 'node', data.eGrab)
         .on('position', 'node', data.ePosition)

--- a/src/cueUtilities.js
+++ b/src/cueUtilities.js
@@ -112,6 +112,10 @@ module.exports = function (params, cy, api) {
         return hoveredGroup && hoveredGroup.id() === node.id();
       }
 
+      function isMouseHoveringOverGroupChild(node) {
+        return hoveredGroup && node.parent().id() === hoveredGroup.id();
+      }
+
       function isAGroup(node) {
         return api.isCollapsible(node) || api.isExpandable(node);
       }
@@ -253,7 +257,7 @@ module.exports = function (params, cy, api) {
 
         cy.on('mouseout', 'node', data.eMouseOut = function(e) {
           let node = this;
-          if (isMouseHoveringOver(node)) {
+          if (isMouseHoveringOver(node) || isMouseHoveringOverGroupChild(node)) {
             // note: hoveredGroup is not set to null if we mouseout from a selected group
             // currently is not a problem as leftover hoveredGroup won't be used and will be reset on mouseover
             if (!isSelectedGroupsContains(hoveredGroup)) {
@@ -268,6 +272,13 @@ module.exports = function (params, cy, api) {
           if (isAGroup(node)) {
             hoveredGroup = node;
             refreshCanvasImages();
+          } else if (!node.isParent()) {
+            // if we are in a groups child
+            const parent = node.parent();
+            if (parent.length > 0) {
+              hoveredGroup = node.parent();
+              refreshCanvasImages();
+            }
           }
         });
 

--- a/src/cueUtilities.js
+++ b/src/cueUtilities.js
@@ -291,7 +291,7 @@ module.exports = function (params, cy, api) {
             var bottomRight = {
               x: (node.position("x") + node.width() / 2 + parseFloat(node.css('padding-right'))),
               y: (node.position("y") + node.height() / 2+ parseFloat(node.css('padding-bottom')))};
-    
+
             if (currMousePos.x >= topLeft.x && currMousePos.y >= topLeft.y &&
               currMousePos.x <= bottomRight.x && currMousePos.y <= bottomRight.y){
               return true;
@@ -352,7 +352,7 @@ module.exports = function (params, cy, api) {
           drawCueOnHighestZDepthGroup(e);
         });
 
-        cy.on('mouseoff', 'edge', data.eMouseOffEdge = function(e) {
+        cy.on('mouseout', 'edge', data.eMouseOutEdge = function(e) {
           if (hoveredGroup) {
             hoveredGroup = null;
           }
@@ -360,7 +360,7 @@ module.exports = function (params, cy, api) {
 
         cy.on('mousemove', 'node', data.eMouseMoveNode = function(e) {
           let node = this;
-          if (!isAGroup(node) && parent.length === 0) {
+          if (!isAGroup(node)) {
             drawCueOnHighestZDepthGroup(e);
           }
         });
@@ -549,7 +549,7 @@ module.exports = function (params, cy, api) {
           .off('zoom pan', data.eZoom)
           .off('drag', 'node', data.eDrag)
           .off('mousemove', 'edge', data.eMouseMove)
-          .off('mouseoff', 'edge', data.eMouseOffEdge);
+          .off('mouseout', 'edge', data.eMouseOutEdge);
 
       window.removeEventListener('resize', data.eWindowResize);
       $canvas.removeEventListener('mousedown', interceptEventWithinCue);
@@ -581,7 +581,7 @@ module.exports = function (params, cy, api) {
         .on('zoom pan', data.eZoom)
         .on('drag', 'node', data.eDrag)
         .on('mousemove', 'edge', data.eMouseMove)
-        .on('mouseoff', 'edge', data.eMouseOffEdge);
+        .on('mouseout', 'edge', data.eMouseOutEdge);
 
       window.addEventListener('resize', data.eWindowResize);
       $canvas.addEventListener('mousedown', interceptCytoscapeEventsWithinCue);


### PR DESCRIPTION
Cue always appears when hovering over a group, even if mouse is also over edge/node