### PR TITLE
[DCE-1826] Use both z-index and z-depth to determine groups on top.

### DIFF
--- a/src/cueUtilities.js
+++ b/src/cueUtilities.js
@@ -318,13 +318,16 @@ module.exports = function (params, cy, api) {
         function getAllGroupsWithHighestZDepth(groups) {
           let highestZDepthGroups = [];
           let highestZDepth = 0;
+          let highestZIndexWithinZDepth = 0;
           groups.forEach((group) => {
-            let currentZDepth = group.zDepth();
-            // if we find groups with a higher zDepth, keep track of those
-            if (currentZDepth > highestZDepth) {
+            let currentZDepth = group.zDepth();         // zDepth is depth of element on graph e.g. child nodes have > z depth than their parents
+            let currentZIndex = group.style('z-index'); // z-index is order of elements at same z depth
+            // if we find groups with a higher zDepth/zIndex combo, keep track of those
+            if (currentZDepth > highestZDepth || (currentZDepth === highestZDepth && currentZIndex > highestZIndex)) {
               highestZDepth = currentZDepth;
+              highestZIndex = currentZIndex;
               highestZDepthGroups = [group];
-            } else if (currentZDepth === highestZDepth) {
+            } else if (currentZDepth === highestZDepth && currentZIndex === highestZIndex) {
               highestZDepthGroups.push(group);
             }
           });


### PR DESCRIPTION
Fix code determining which group is on top to use both z-depth (which comes from order of child nodes within their parents) and z-index (which determines order of drawing when z-depth is same). Previously, hover cue was sometimes drawing on a group with a lower z-index.